### PR TITLE
Enhance overrides functions and add some runtime properties

### DIFF
--- a/kube_plugin/tasks.py
+++ b/kube_plugin/tasks.py
@@ -142,7 +142,7 @@ def kube_run_expose(**kwargs):
     fname="/tmp/kub_{}.yaml".format(ctx.instance.id)
     with open(fname,'w') as f:
       yaml.safe_dump(d,f)
-    cmd="./kubectl -s http://localhost:8080 create -f "+fname + " >> /tmp/kubectl.out 2>&1"
+    cmd="sudo /usr/local/bin/kubectl -s http://localhost:8080 create -f "+fname + " >> /tmp/kubectl.out 2>&1"
     ctx.logger.info("running create: {}".format(cmd))
 
     #retry a few times
@@ -173,14 +173,14 @@ def kube_run_expose(**kwargs):
       write_and_run(base)
   else:
     # do kubectl run
-    cmd='./kubectl -s http://localhost:8080 run {} --image={} --port={} --replicas={}'.format(ctx.node.properties['name'],ctx.node.properties['image'],ctx.node.properties['target_port'],ctx.node.properties['replicas'])
+    cmd='sudo /usr/local/bin/kubectl -s http://localhost:8080 run {} --image={} --port={} --replicas={}'.format(ctx.node.properties['name'],ctx.node.properties['image'],ctx.node.properties['target_port'],ctx.node.properties['replicas'])
     if(ctx.node.properties['run_overrides']):
       cmd=cmd+" --overrides={}".format(ctx.node.properties['run_overrides'])
 
     subprocess.call(cmd,True)
 
     # do kubectl expose
-    cmd='./kubectl -s http://localhost:8080 expose rc {} --port={} --protocol={}'.format(ctx.node.properties['name'],ctx.node.properties['port'],ctx.node.properties['protocol'])
+    cmd='sudo /usr/local/bin/kubectl -s http://localhost:8080 expose rc {} --port={} --protocol={}'.format(ctx.node.properties['name'],ctx.node.properties['port'],ctx.node.properties['protocol'])
     if(ctx.node.properties['expose_overrides']):
       cmd=cmd+" --overrides={}".format(ctx.node.properties['expose_overrides'])
 

--- a/kube_plugin/workflows.py
+++ b/kube_plugin/workflows.py
@@ -21,7 +21,7 @@ def kube_scale(**kwargs):
 
   #if the request is an increment, get current value
   if(kwargs['amount'][0]=='+' or kwargs['amount'][0]=='-'):
-    output=run("./kubectl -s http://localhost:8080 get rc --no-headers {}".format(name))
+    output=run("sudo /usr/local/bin/kubectl -s http://localhost:8080 get rc --no-headers {}".format(name))
     curinstances=int(output.stdout.split()[4])
     inc=int(kwargs['amount'])
     amount=curinstances+inc
@@ -29,8 +29,8 @@ def kube_scale(**kwargs):
     amount=int(kwargs['amount'])
 
   with open("/tmp/log","a") as f:
-    f.write("running: ./kubectl -s http://localhost:8080 scale --replicas={} rc {}".format(amount,name))
-  run("./kubectl -s http://localhost:8080 scale --replicas={} rc {}".format(amount,name))
+    f.write("running: sudo /usr/local/bin/kubectl -s http://localhost:8080 scale --replicas={} rc {}".format(amount,name))
+  run("sudo /usr/local/bin/kubectl -s http://localhost:8080 scale --replicas={} rc {}".format(amount,name))
 
 #
 # Run an image on the cluster pointed to by the master arg
@@ -52,7 +52,7 @@ def kube_create(**kwargs):
     
     put(res,"/tmp/manifest.yaml")
 
-  run("./kubectl -s http://localhost:8080 create -f /tmp/manifest.yaml")
+  run("sudo /usr/local/bin/kubectl -s http://localhost:8080 create -f /tmp/manifest.yaml")
 
 #
 # Run an image on the cluster pointed to by the master arg
@@ -62,7 +62,7 @@ def kube_run(**kwargs):
   setfabenv(kwargs)
   optstr=buildopts(kwargs,{"dry_run":"dry-run"},{"port":"not _val_ == -1"},["dry_run"],['name','master'])
   ctx.logger.info("Running: {}".format(optstr))
-  run("./kubectl -s http://localhost:8080 run "+" "+kwargs['name']+optstr)
+  run("sudo /usr/local/bin/kubectl -s http://localhost:8080 run "+" "+kwargs['name']+optstr)
 
 #
 # Expose an app
@@ -71,7 +71,7 @@ def kube_run(**kwargs):
 def kube_expose(**kwargs):
   setfabenv(kwargs)
   optstr=buildopts(kwargs,{"target_port":"target-port","service_name":"service-name"},{"target_port":"not _val_ == -1"},[],['name','master','resource'])
-  runstr="./kubectl -s http://localhost:8080 expose {} {} {}".format(kwargs['resource'],kwargs['name'],optstr)
+  runstr="sudo /usr/local/bin/kubectl -s http://localhost:8080 expose {} {} {}".format(kwargs['resource'],kwargs['name'],optstr)
   ctx.logger.info("Running: {}".format(runstr))
   run(runstr)
   
@@ -82,7 +82,7 @@ def kube_expose(**kwargs):
 def kube_stop(**kwargs):
   setfabenv(kwargs)
   optstr=buildopts(kwargs,{},{},["all"],['name','master','resource'])
-  runstr="./kubectl -s http://localhost:8080 stop {} {} {}".format(kwargs['resource'],kwargs['name'],optstr)
+  runstr="sudo /usr/local/bin/kubectl -s http://localhost:8080 stop {} {} {}".format(kwargs['resource'],kwargs['name'],optstr)
   ctx.logger.info("Running: {}".format(runstr))
   run(runstr)
   
@@ -93,7 +93,7 @@ def kube_stop(**kwargs):
 def kube_delete(**kwargs):
   setfabenv(kwargs)
   optstr=buildopts(kwargs,{},{},["all"],['name','master','resource'])
-  runstr="./kubectl -s http://localhost:8080 delete {} {} {}".format(kwargs['resource'],kwargs['name'],optstr)
+  runstr="sudo /usr/local/bin/kubectl -s http://localhost:8080 delete {} {} {}".format(kwargs['resource'],kwargs['name'],optstr)
   ctx.logger.info("Running: {}".format(runstr))
   with open("/tmp/log","a") as f:
     f.write("executing {}\n".format(runstr))

--- a/plugin-remote.yaml
+++ b/plugin-remote.yaml
@@ -1,7 +1,7 @@
 plugins:
   kubernetes:
     executor: central_deployment_agent
-    source: https://www.github.com/cloudify-examples/cloudify-kubernetes-plugin/archive/1.3.1.zip
+    source: cloudify-kubernetes-plugin
 
 node_types:
   cloudify.kubernetes.Base:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 plugins:
   kubernetes:
     executor: host_agent
-    source: https://www.github.com/cloudify-examples/cloudify-kubernetes-plugin/archive/1.3.1.zip
+    source: cloudify-kubernetes-plugin
 
 node_types:
   cloudify.kubernetes.Base:


### PR DESCRIPTION
- Add `sudo` to commands using kubectl
- Change the structure of the 'kinds' variable in runtime property 
- Add some properties from kubernetes services into runtime properties (clusterIP, NodePort)
- Add/Change functions in the kubernetes overrides sections:
  - `@{node_name, property_name }`
    Retrieve a property or runtime property value.
  - `@{get_service, node_name, clusterIP}`
    Retrieve the clusterIP value from the runtime property of the given node
  - `@{get_service, node_name, port}`
    Retrieve the NodePort value from the runtime property of the given node

With these changes, one can build a nodecellar blueprint in full docker.
Or build an hybrid blueprint with the mongo node declared inside only one blueprint.